### PR TITLE
Add optional nameMap argument to Dataset.toFile()

### DIFF
--- a/src/Dataset.js
+++ b/src/Dataset.js
@@ -145,8 +145,10 @@ class Dataset {
    * @param {string} path - P10 file path.
    * @param {function(Error)} [callback] - P10 file writing callback function.
    * If this is not provided, the function runs synchronously.
+   * @param {object} nameMap - Additional DICOM tags to recognize when denaturalizing the
+   * dataset. Can be used to support writing private fields/tags. Optional.
    */
-  toFile(path, callback) {
+  toFile(path, callback, nameMap) {
     const elements = {
       _meta: {
         FileMetaInformationVersion: new Uint8Array([0, 1]).buffer,
@@ -162,7 +164,15 @@ class Dataset {
     };
     const denaturalizedMetaHeader = DicomMetaDictionary.denaturalizeDataset(elements._meta);
     const dicomDict = new DicomDict(denaturalizedMetaHeader);
-    dicomDict.dict = DicomMetaDictionary.denaturalizeDataset(elements);
+
+    if (nameMap) {
+      dicomDict.dict = DicomMetaDictionary.denaturalizeDataset(elements, {
+        ...DicomMetaDictionary.nameMap,
+        ...nameMap,
+      });
+    } else {
+      dicomDict.dict = DicomMetaDictionary.denaturalizeDataset(elements);
+    }
 
     if (callback !== undefined && callback instanceof Function) {
       fs.writeFile(path, Buffer.from(dicomDict.write()), callback);


### PR DESCRIPTION
Allows parsing in additional dicom tags to the toFile method which will be recognized when denaturalizing the dataset and so  will not be stripped.