### PR TITLE
Prefer the presentation context that exactly matches a request's transfer syntax

### DIFF
--- a/src/Association.js
+++ b/src/Association.js
@@ -439,15 +439,33 @@ class Association {
   getAcceptedPresentationContextFromRequest(request) {
     let acceptedContext = undefined;
     const contexts = this.getPresentationContexts();
-    contexts.forEach((pc) => {
-      const context = this.getPresentationContext(pc.id);
-      if (
-        context.getAbstractSyntaxUid() === this._sopClassFromRequest(request) &&
-        context.getResult() === PresentationContextResult.Accept
-      ) {
-        acceptedContext = context;
-      }
-    });
+
+    // Look for a presentation context which is an exact match for this request's transfer syntax
+    if (request.getDataset()) {
+      contexts.forEach((pc) => {
+        const context = this.getPresentationContext(pc.id);
+        if (
+          context.getAbstractSyntaxUid() === this._sopClassFromRequest(request) &&
+          context.getAcceptedTransferSyntaxUid() === request.getDataset().getTransferSyntaxUid() &&
+          context.getResult() === PresentationContextResult.Accept
+        ) {
+          acceptedContext = context;
+        }
+      });
+    }
+
+    // If there was no exact transfer syntax match then look for a match based just on the abstract syntax
+    if (acceptedContext === undefined) {
+      contexts.forEach((pc) => {
+        const context = this.getPresentationContext(pc.id);
+        if (
+          context.getAbstractSyntaxUid() === this._sopClassFromRequest(request) &&
+          context.getResult() === PresentationContextResult.Accept
+        ) {
+          acceptedContext = context;
+        }
+      });
+    }
 
     return acceptedContext;
   }


### PR DESCRIPTION
This is intended to better handle cases when the same Abstract Syntax is specified in multiple proposed PCs, e.g.

- PC 1: `UltrasoundImageStorage`, transfer syntax: `ExplicitVRLittleEndian`
- PC 3: `UltrasoundImageStorage`, transfer syntax: `JpegBaseline`

And both PCs are accepted by the server.

In this case, a `C-GET` of `UltrasoundImageStorage` data that is natively stored in `JpegBaseline` is best to use PC 3 to avoid a decompression to `ExplicitVRLittleEndian` on the server. Similarly, a `C-GET` of data natively stored in `ExplicitVRLittleEndian` is best to use PC 1.

This PR adds additional logic for this in `Association.getAcceptedPresentationContextFromRequest()`.

This situation is described in the pynetdicom docs here: https://pydicom.github.io/pynetdicom/stable/user/presentation.html, in particular the part starting "If you have data encoded in a variety of transfer syntaxes...".

Thoughts?