### PR TITLE
Implemented C-CANCEL for C-FIND, C-MOVE or C-GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Part of the networking code was taken from [dicom-dimse][dicom-dimse-url].
 	npm run build
 
 ### Features
-- Implements C-ECHO, C-FIND, C-STORE, C-MOVE, C-GET, N-CREATE, N-ACTION, N-DELETE, N-EVENT-REPORT, N-GET and N-SET services as SCU and SCP.
+- Implements C-ECHO, C-FIND, C-STORE, C-MOVE, C-GET, C-CANCEL, N-CREATE, N-ACTION, N-DELETE, N-EVENT-REPORT, N-GET and N-SET services as SCU and SCP.
 - Supports secure DICOM TLS connections.
 - Allows custom DICOM implementations (Implementation Class UID and Implementation Version).
 - Provides asynchronous event handlers for incoming SCP requests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs-dimse",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs-dimse",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "DICOM DIMSE implementation for Node.js using dcmjs",
   "main": "build/dcmjs-dimse.min.js",
   "module": "build/dcmjs-dimse.min.js",

--- a/src/Command.js
+++ b/src/Command.js
@@ -1833,6 +1833,61 @@ class NSetResponse extends Response {
 }
 //#endregion
 
+//#region CCancelRequest
+class CCancelRequest extends Request {
+  /**
+   * Creates an instance of CCancelRequest.
+   * @constructor
+   * @param {string} affectedSopClassUid - Affected SOP class UID.
+   * @param {number} messageId - Message ID to cancel.
+   */
+  constructor(affectedSopClassUid, messageId) {
+    super(CommandFieldType.CCancelRequest, affectedSopClassUid, false);
+    this.setMessageIdBeingRespondedTo(messageId);
+  }
+
+  /**
+   * Gets message ID to cancel.
+   * @method
+   * @return {number} Message ID to cancel.
+   */
+  getMessageIdBeingRespondedTo() {
+    const command = this.getCommandDataset();
+    return command.getElement('MessageIDBeingRespondedTo');
+  }
+
+  /**
+   * Sets message ID to cancel.
+   * @method
+   * @param {number} messageId - Message ID to cancel.
+   */
+  setMessageIdBeingRespondedTo(messageId) {
+    const command = this.getCommandDataset();
+    command.setElement('MessageIDBeingRespondedTo', messageId);
+  }
+
+  /**
+   * Creates a C-CANCEL request from a C-FIND, C-MOVE or C-GET request.
+   * @method
+   * @static
+   * @param {CFindRequest|CMoveRequest|CGetRequest} request - C-FIND, C-MOVE or C-GET request.
+   * @returns {CCancelRequest} C-CANCEL request.
+   * @throws Error if request is not an instance of CFindRequest, CMoveRequest or CGetRequest.
+   */
+  static fromRequest(request) {
+    if (
+      !(request instanceof CFindRequest) &&
+      !(request instanceof CMoveRequest) &&
+      !(request instanceof CGetRequest)
+    ) {
+      throw new Error('Request should be an instance of CFindRequest, CMoveRequest or CGetRequest');
+    }
+
+    return new CCancelRequest(request.getAffectedSopClassUid(), request.getMessageId());
+  }
+}
+//#endregion
+
 //#region Exports
 module.exports = {
   Command,
@@ -1860,5 +1915,6 @@ module.exports = {
   NGetResponse,
   NSetRequest,
   NSetResponse,
+  CCancelRequest,
 };
 //#endregion

--- a/src/Server.js
+++ b/src/Server.js
@@ -86,6 +86,9 @@ class Scp extends Network {
     this.on('nSetRequest', (request, callback) => {
       this.nSetRequest(request, callback);
     });
+    this.on('cCancelRequest', (request) => {
+      this.cCancelRequest(request);
+    });
   }
 
   /**
@@ -229,6 +232,16 @@ class Scp extends Network {
   nSetRequest(request, callback) {
     log.error('nSetRequest method must be implemented');
     callback(NSetResponse.fromRequest(request));
+  }
+
+  /**
+   * C-CANCEL request received.
+   * @method
+   * @param {CCancelRequest} request - C-CANCEL request.
+   */
+  // eslint-disable-next-line no-unused-vars
+  cCancelRequest(request) {
+    log.error('cCancelRequest method must be implemented');
   }
 }
 /* c8 ignore stop */

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ const {
   NGetResponse,
   NSetRequest,
   NSetResponse,
+  CCancelRequest,
 } = require('./Command');
 const {
   CommandFieldType,
@@ -65,6 +66,7 @@ const requests = {
   NEventReportRequest,
   NGetRequest,
   NSetRequest,
+  CCancelRequest,
 };
 //#endregion
 

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-module.exports = '0.1.5';
+module.exports = '0.1.6';

--- a/test/Commands.test.js
+++ b/test/Commands.test.js
@@ -24,6 +24,7 @@ const {
   NGetResponse,
   NSetRequest,
   NSetResponse,
+  CCancelRequest,
 } = require('./../src/Command');
 const Dataset = require('../src/Dataset');
 const {
@@ -91,6 +92,13 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.CEchoResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      CEchoResponse.fromRequest(new CFindRequest());
+    }).to.throw();
+    expect(() => {
+      CEchoResponse.fromRequest(new CEchoRequest());
+    }).to.not.throw();
   });
 
   it('should correctly create a C-FIND request', () => {
@@ -122,6 +130,13 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.CFindResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      CFindResponse.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      CFindResponse.fromRequest(new CFindRequest());
+    }).to.not.throw();
   });
 
   it('should correctly create a C-STORE request', () => {
@@ -162,6 +177,13 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.CStoreResponse);
     expect(response.getStatus()).to.be.eq(Status.Success);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      CStoreResponse.fromRequest(new CFindRequest());
+    }).to.throw();
+    expect(() => {
+      CStoreResponse.fromRequest(new CStoreRequest(new Dataset({ PatientID: 12345 })));
+    }).to.not.throw();
   });
 
   it('should correctly create a C-MOVE request', () => {
@@ -190,6 +212,13 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.CMoveResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      CMoveResponse.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      CMoveResponse.fromRequest(new CMoveRequest());
+    }).to.not.throw();
   });
 
   it('should correctly create a C-GET request', () => {
@@ -216,6 +245,13 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.CGetResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      CGetResponse.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      CGetResponse.fromRequest(new CGetRequest());
+    }).to.not.throw();
   });
 
   it('should correctly create a N-CREATE request', () => {
@@ -239,6 +275,13 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.NCreateResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      NCreateResponse.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      NCreateResponse.fromRequest(new NCreateRequest(sopClassUid, sopInstanceUid));
+    }).to.not.throw();
   });
 
   it('should correctly create a N-ACTION request', () => {
@@ -269,6 +312,13 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.NActionResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      NActionResponse.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      NActionResponse.fromRequest(new NActionRequest(sopClassUid, sopInstanceUid, 0x0002));
+    }).to.not.throw();
   });
 
   it('should correctly create a N-DELETE request', () => {
@@ -292,6 +342,13 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.NDeleteResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      NDeleteResponse.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      NDeleteResponse.fromRequest(new NDeleteRequest(sopClassUid, sopInstanceUid));
+    }).to.not.throw();
   });
 
   it('should correctly create a N-EVENT-REPORT request', () => {
@@ -322,6 +379,15 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.NEventReportResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      NEventReportResponse.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      NEventReportResponse.fromRequest(
+        new NEventReportRequest(sopClassUid, sopInstanceUid, 0x0002)
+      );
+    }).to.not.throw();
   });
 
   it('should correctly create a N-GET request', () => {
@@ -362,6 +428,15 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.NGetResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      NGetResponse.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      NGetResponse.fromRequest(
+        new NGetRequest(sopClassUid, sopInstanceUid, ['PatientID', 'PatientName'])
+      );
+    }).to.not.throw();
   });
 
   it('should correctly create a N-SET request', () => {
@@ -385,5 +460,29 @@ describe('Command', () => {
     expect(response.getCommandFieldType()).to.be.eq(CommandFieldType.NSetResponse);
     expect(response.getStatus()).to.be.eq(Status.ProcessingFailure);
     expect(response.hasDataset()).to.be.false;
+
+    expect(() => {
+      NSetResponse.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      NSetResponse.fromRequest(new NSetRequest(sopClassUid, sopInstanceUid));
+    }).to.not.throw();
+  });
+
+  it('should correctly create a C-CANCEL request', () => {
+    const sopClassUid = Dataset.generateDerivedUid();
+    const request = new CCancelRequest(sopClassUid, 2);
+
+    expect(request.getAffectedSopClassUid()).to.be.eq(sopClassUid);
+    expect(request.getCommandFieldType()).to.be.eq(CommandFieldType.CCancelRequest);
+    expect(request.getMessageIdBeingRespondedTo()).to.be.eq(2);
+    expect(request.hasDataset()).to.be.false;
+
+    expect(() => {
+      CCancelRequest.fromRequest(new CEchoRequest());
+    }).to.throw();
+    expect(() => {
+      CCancelRequest.fromRequest(new CFindRequest());
+    }).to.not.throw();
   });
 });


### PR DESCRIPTION
This pull request closes #16.

@richard-viney please review and let me know of your thoughts.
Client-side cancellation was tested with DVTk Query Retrieve SCP Emulator (https://www.dvtk.org/dicom/query-retrieve-scp-emulator) and found to be working as expected.