### PR TITLE
Added support for writing received DICOM content to Writable streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Part of the networking code was taken from [dicom-dimse][dicom-dimse-url].
 - Supports secure DICOM TLS connections and user identity negotiation.
 - Transcodes sent and received datasets among all major accepted transfer syntaxes (using the [dcmjs-codecs][dcmjs-codecs-url] library).
 - Allows custom DICOM implementations (Implementation Class UID and Implementation Version).
-- Provides asynchronous event handlers for incoming SCP requests.
+- Provides asynchronous event handlers and streaming support for incoming SCP requests.
 
 
 #### Supported Transfer Syntaxes

--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ Please check the respecting [Wiki][dcmjs-dimse-wiki-examples-url] section for mo
 ### License
 dcmjs-dimse is released under the MIT License.
 
+### Sponsors
+The following organizations supported the dcmjs-dimse development.
+* [HeartLab][sponsors-heartlab-url] - A Cardiology Imaging Platform That Lets You Work Smarter.
+
 [npm-url]: https://npmjs.org/package/dcmjs-dimse
 [npm-version-image]: https://img.shields.io/npm/v/dcmjs-dimse.svg?style=flat
 [npm-downloads-image]: http://img.shields.io/npm/dm/dcmjs-dimse.svg?style=flat
@@ -332,3 +336,5 @@ dcmjs-dimse is released under the MIT License.
 [dcmjs-ecg-url]: https://github.com/PantelisGeorgiadis/dcmjs-ecg
 
 [dcmjs-dimse-wiki-examples-url]: https://github.com/PantelisGeorgiadis/dcmjs-dimse/wiki/Examples
+
+[sponsors-heartlab-url]: https://heartlab.com

--- a/index.d.ts
+++ b/index.d.ts
@@ -1478,7 +1478,10 @@ declare class Scp extends Network {
    * The default implementation creates a memory Writable stream that for, big instances,
    * could cause out of memory situations.
    */
-  createStoreWritableStream(acceptedPresentationContext: PresentationContext): Writable;
+  createStoreWritableStream(
+    acceptedPresentationContext: PresentationContext,
+    request: CStoreRequest
+  ): Writable;
 
   /**
    * Allows the caller to create a Dataset from the Writable stream used to

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import { Socket } from 'net';
 import { SecureContext, TLSSocket } from 'tls';
 import { Mixin } from 'ts-mixer';
 import { Logger } from 'winston';
+import { Writable } from 'stream';
 
 declare namespace PresentationContextResult {
   const Proposed: number;
@@ -1471,6 +1472,24 @@ declare class Scp extends Network {
       };
     }
   );
+
+  /**
+   * Allows the caller to create a Writable stream to accumulate the C-STORE dataset.
+   * The default implementation creates a memory Writable stream that for, big instances,
+   * could cause out of memory situations.
+   */
+  createStoreWritableStream(acceptedPresentationContext: PresentationContext): Writable;
+
+  /**
+   * Allows the caller to create a Dataset from the Writable stream used to
+   * accumulate the C-STORE dataset. The created Dataset is passed to the
+   * Scp.cStoreRequest method for processing.
+   */
+  createDatasetFromStoreWritableStream(
+    writable: Writable,
+    acceptedPresentationContext: PresentationContext,
+    callback: (dataset: Dataset) => void
+  ): void;
 
   /**
    * Association request received.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,7 @@
 import { Socket } from 'net';
 import { SecureContext, TLSSocket } from 'tls';
 import { expectError, expectType } from 'tsd';
+import { Writable } from 'stream';
 
 import {
   Client,
@@ -482,6 +483,19 @@ class TestScp extends Scp {
     }
   ) {
     super(socket, opts);
+  }
+  createStoreWritableStream(
+    acceptedPresentationContext: association.PresentationContext,
+    request: requests.CStoreRequest
+  ): Writable {
+    return new Writable();
+  }
+  createDatasetFromStoreWritableStream(
+    writable: Writable,
+    acceptedPresentationContext: association.PresentationContext,
+    callback: (dataset: Dataset) => void
+  ): void {
+    callback(new Dataset({}, TransferSyntax.ImplicitVRLittleEndian));
   }
   associationRequested(association: association.Association) {}
   associationReleaseRequested() {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dcmjs-dimse",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dcmjs-dimse",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "async-eventemitter": "^0.2.4",
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/async-eventemitter": "^0.2.4",
-        "@types/node": "^22.13.4",
+        "@types/node": "^22.13.10",
         "c8": "^9.1.0",
         "chai": "^4.3.10",
         "docdash": "^2.0.2",
@@ -632,9 +632,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1593,9 +1593,9 @@
       }
     },
     "node_modules/dcmjs": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/dcmjs/-/dcmjs-0.38.1.tgz",
-      "integrity": "sha512-amSv71Gs/Yd8DRLcvS15dGlcWjpSHt5h6NTj8ozWRRuKIP5BgXhAnPPzrsJTXs+LDm13JDA8Ip2/7WLo5qfzhA==",
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/dcmjs/-/dcmjs-0.38.3.tgz",
+      "integrity": "sha512-evxUair/D7zI3ilpDI8wTOtVq8OVa1XiMAAVOid99KCPCvXgPIBOLU4VrG4pS3sgqDJRqRcw0pCC8kaMiXNv9A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.5",
@@ -6787,9 +6787,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "requires": {
         "undici-types": "~6.20.0"
@@ -7531,9 +7531,9 @@
       }
     },
     "dcmjs": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/dcmjs/-/dcmjs-0.38.1.tgz",
-      "integrity": "sha512-amSv71Gs/Yd8DRLcvS15dGlcWjpSHt5h6NTj8ozWRRuKIP5BgXhAnPPzrsJTXs+LDm13JDA8Ip2/7WLo5qfzhA==",
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/dcmjs/-/dcmjs-0.38.3.tgz",
+      "integrity": "sha512-evxUair/D7zI3ilpDI8wTOtVq8OVa1XiMAAVOid99KCPCvXgPIBOLU4VrG4pS3sgqDJRqRcw0pCC8kaMiXNv9A==",
       "requires": {
         "@babel/runtime-corejs3": "^7.22.5",
         "adm-zip": "^0.5.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "async-eventemitter": "^0.2.4",
         "dcmjs": "^0.38.1",
         "dcmjs-codecs": "^0.0.5",
+        "memorystream": "^0.3.1",
         "smart-buffer": "^4.2.0",
         "ts-mixer": "^6.0.4",
         "winston": "^3.17.0"
@@ -3276,6 +3277,14 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/meow": {
       "version": "11.0.0",
@@ -8756,6 +8765,11 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw=="
     },
     "meow": {
       "version": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "async-eventemitter": "^0.2.4",
     "dcmjs": "^0.38.1",
     "dcmjs-codecs": "^0.0.5",
+    "memorystream": "^0.3.1",
     "smart-buffer": "^4.2.0",
     "ts-mixer": "^6.0.4",
     "winston": "^3.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs-dimse",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DICOM DIMSE implementation for Node.js using dcmjs",
   "main": "build/dcmjs-dimse.min.js",
   "module": "build/dcmjs-dimse.min.js",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@types/async-eventemitter": "^0.2.4",
-    "@types/node": "^22.13.4",
+    "@types/node": "^22.13.10",
     "c8": "^9.1.0",
     "chai": "^4.3.10",
     "docdash": "^2.0.2",

--- a/src/Dataset.js
+++ b/src/Dataset.js
@@ -40,10 +40,6 @@ class Dataset {
   /**
    * Gets element value.
    * @method
-   * @param {string}
-  /**
-   * Gets element value.
-   * @method
    * @param {string} tag - Element tag.
    * @returns {string|undefined} Element value or undefined if element doesn't exist.
    */

--- a/src/Dataset.js
+++ b/src/Dataset.js
@@ -40,6 +40,10 @@ class Dataset {
   /**
    * Gets element value.
    * @method
+   * @param {string}
+  /**
+   * Gets element value.
+   * @method
    * @param {string} tag - Element tag.
    * @returns {string|undefined} Element value or undefined if element doesn't exist.
    */

--- a/src/Network.js
+++ b/src/Network.js
@@ -513,7 +513,7 @@ class Network extends AsyncEventEmitter {
     }
   }
 
-/**
+  /**
    * Process P-DATA-TF.
    * @method
    * @private
@@ -663,7 +663,7 @@ class Network extends AsyncEventEmitter {
               const dataset = new Dataset(
                 this.dimseStream.toBuffer(),
                 presentationContext.getAcceptedTransferSyntaxUid(),
-				this.datasetReadOptions
+                this.datasetReadOptions
               );
               this.dimse.setDataset(dataset);
               this._performDimse(presentationContext, this.dimse);

--- a/src/Network.js
+++ b/src/Network.js
@@ -47,6 +47,7 @@ const log = require('./log');
 const { SmartBuffer } = require('smart-buffer');
 const { EOL } = require('os');
 const AsyncEventEmitter = require('async-eventemitter');
+const MemoryStream = require('memorystream');
 
 //#region Network
 class Network extends AsyncEventEmitter {
@@ -72,7 +73,8 @@ class Network extends AsyncEventEmitter {
     this.requests = [];
     this.pending = [];
 
-    this.dimseBuffer = undefined;
+    this.dimseStream = undefined;
+    this.dimseStoreStream = undefined;
     this.dimse = undefined;
 
     opts = opts || {};
@@ -230,6 +232,36 @@ class Network extends AsyncEventEmitter {
    */
   getStatistics() {
     return this.statistics;
+  }
+
+  /**
+   * Allows the caller to create a Writable stream to accumulate the C-STORE dataset.
+   * The default implementation creates a memory Writable stream that for, big instances,
+   * could cause out of memory situations.
+   * @method
+   * @param {PresentationContext} acceptedPresentationContext - The accepted presentation context.
+   * @returns {Writable} The created store writable stream.
+   */
+  // eslint-disable-next-line no-unused-vars
+  createStoreWritableStream(acceptedPresentationContext) {
+    return MemoryStream.createWriteStream();
+  }
+
+  /**
+   * Allows the caller to create a Dataset from the Writable stream used to
+   * accumulate the C-STORE dataset. The created Dataset is passed to the
+   * Scp.cStoreRequest method for processing.
+   * @method
+   * @param {Writable} writable - The store writable stream.
+   * @param {PresentationContext} acceptedPresentationContext - The accepted presentation context.
+   * @param {function(Dataset)} callback - Created dataset callback function.
+   */
+  createDatasetFromStoreWritableStream(writable, acceptedPresentationContext, callback) {
+    const dataset = new Dataset(
+      writable.toBuffer(),
+      acceptedPresentationContext.getAcceptedTransferSyntaxUid()
+    );
+    callback(dataset);
   }
 
   //#region Private Methods
@@ -481,7 +513,7 @@ class Network extends AsyncEventEmitter {
     }
   }
 
-  /**
+/**
    * Process P-DATA-TF.
    * @method
    * @private
@@ -491,18 +523,37 @@ class Network extends AsyncEventEmitter {
     try {
       const pdvs = pdu.getPdvs();
       pdvs.forEach((pdv) => {
-        if (!this.dimseBuffer) {
-          this.dimseBuffer = SmartBuffer.fromOptions({
-            encoding: 'ascii',
-          });
-        }
-        this.dimseBuffer.writeBuffer(pdv.getValue());
         const presentationContext = this.association.getPresentationContext(
           pdv.getPresentationContextId()
         );
+
+        if (!this.dimse) {
+          // Create stream to receive command
+          if (!this.dimseStream) {
+            this.dimseStream = MemoryStream.createWriteStream();
+            this.dimseStoreStream = undefined;
+          }
+        } else {
+          // Create stream to receive dataset
+          if (this.dimse.getCommandFieldType() === CommandFieldType.CStoreRequest) {
+            if (!this.dimseStoreStream) {
+              this.dimseStream = undefined;
+              this.dimseStoreStream = this.createStoreWritableStream(presentationContext);
+            }
+          } else {
+            if (!this.dimseStream) {
+              this.dimseStream = MemoryStream.createWriteStream();
+              this.dimseStoreStream = undefined;
+            }
+          }
+        }
+
+        const stream = this.dimseStream || this.dimseStoreStream;
+        stream.write(pdv.getValue());
+
         if (pdv.isLastFragment()) {
           if (pdv.isCommand()) {
-            const command = new Command(new Dataset(this.dimseBuffer.toBuffer()));
+            const command = new Command(new Dataset(this.dimseStream.toBuffer()));
             const type = command.getCommandFieldType();
             switch (type) {
               case CommandFieldType.CEchoRequest:
@@ -591,17 +642,35 @@ class Network extends AsyncEventEmitter {
               this.dimse = undefined;
               return;
             }
-            this.dimseBuffer = undefined;
+            this.dimseStream = undefined;
+            this.dimseStoreStream = undefined;
           } else {
-            const dataset = new Dataset(
-              this.dimseBuffer.toBuffer(),
-              presentationContext.getAcceptedTransferSyntaxUid(),
-              this.datasetReadOptions
-            );
-            this.dimse.setDataset(dataset);
-            this._performDimse(presentationContext, this.dimse);
-            this.dimseBuffer = undefined;
-            this.dimse = undefined;
+            if (this.dimse.getCommandFieldType() === CommandFieldType.CStoreRequest) {
+              this.dimseStoreStream.end();
+              this.createDatasetFromStoreWritableStream(
+                this.dimseStoreStream,
+                presentationContext,
+                (dataset) => {
+                  this.dimse.setDataset(dataset);
+                  this._performDimse(presentationContext, this.dimse);
+                  this.dimseStream = undefined;
+                  this.dimseStoreStream = undefined;
+                  this.dimse = undefined;
+                }
+              );
+            } else {
+              this.dimseStream.end();
+              const dataset = new Dataset(
+                this.dimseStream.toBuffer(),
+                presentationContext.getAcceptedTransferSyntaxUid(),
+				this.datasetReadOptions
+              );
+              this.dimse.setDataset(dataset);
+              this._performDimse(presentationContext, this.dimse);
+              this.dimseStream = undefined;
+              this.dimseStoreStream = undefined;
+              this.dimse = undefined;
+            }
           }
         }
       });

--- a/src/Network.js
+++ b/src/Network.js
@@ -538,7 +538,10 @@ class Network extends AsyncEventEmitter {
           if (this.dimse.getCommandFieldType() === CommandFieldType.CStoreRequest) {
             if (!this.dimseStoreStream) {
               this.dimseStream = undefined;
-              this.dimseStoreStream = this.createStoreWritableStream(presentationContext);
+              this.dimseStoreStream = this.createStoreWritableStream(
+                presentationContext,
+                this.dimse
+              );
             }
           } else {
             if (!this.dimseStream) {
@@ -549,6 +552,8 @@ class Network extends AsyncEventEmitter {
         }
 
         const stream = this.dimseStream || this.dimseStoreStream;
+
+        // TODO: Add stream backpressure event handling
         stream.write(pdv.getValue());
 
         if (pdv.isLastFragment()) {

--- a/src/Server.js
+++ b/src/Server.js
@@ -107,10 +107,11 @@ class Scp extends Network {
    * could cause out of memory situations.
    * @method
    * @param {PresentationContext} acceptedPresentationContext - The accepted presentation context.
+   * @param {CStoreRequest} request - C-STORE request.
    * @returns {Writable} The created store writable stream.
    */
   // eslint-disable-next-line no-unused-vars
-  createStoreWritableStream(acceptedPresentationContext) {
+  createStoreWritableStream(acceptedPresentationContext, request) {
     return super.createStoreWritableStream();
   }
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -102,6 +102,36 @@ class Scp extends Network {
   }
 
   /**
+   * Allows the caller to create a Writable stream to accumulate the C-STORE dataset.
+   * The default implementation creates a memory Writable stream that for, big instances,
+   * could cause out of memory situations.
+   * @method
+   * @param {PresentationContext} acceptedPresentationContext - The accepted presentation context.
+   * @returns {Writable} The created store writable stream.
+   */
+  // eslint-disable-next-line no-unused-vars
+  createStoreWritableStream(acceptedPresentationContext) {
+    return super.createStoreWritableStream();
+  }
+
+  /**
+   * Allows the caller to create a Dataset from the Writable stream used to
+   * accumulate the C-STORE dataset. The created Dataset is passed to the
+   * Scp.cStoreRequest method for processing.
+   * @method
+   * @param {Writable} writable - The store writable stream.
+   * @param {PresentationContext} acceptedPresentationContext - The accepted presentation context.
+   * @param {function(Dataset)} callback - Created dataset callback function.
+   */
+  createDatasetFromStoreWritableStream(writable, acceptedPresentationContext, callback) {
+    return super.createDatasetFromStoreWritableStream(
+      writable,
+      acceptedPresentationContext,
+      callback
+    );
+  }
+
+  /**
    * Association request received.
    * @method
    * @param {Association} association - Association.

--- a/src/Server.js
+++ b/src/Server.js
@@ -110,9 +110,8 @@ class Scp extends Network {
    * @param {CStoreRequest} request - C-STORE request.
    * @returns {Writable} The created store writable stream.
    */
-  // eslint-disable-next-line no-unused-vars
   createStoreWritableStream(acceptedPresentationContext, request) {
-    return super.createStoreWritableStream();
+    return super.createStoreWritableStream(acceptedPresentationContext, request);
   }
 
   /**

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-module.exports = '0.2.0';
+module.exports = '0.2.1';

--- a/test/Dataset.test.js
+++ b/test/Dataset.test.js
@@ -156,7 +156,7 @@ describe('Dataset', () => {
     mockFs.restore();
   });
 
-  it('should correctly read and write DICOM part10 files asynchronously', () => {
+  it('should correctly read and write DICOM part10 files asynchronously', (done) => {
     mockFs({
       'fileIn.dcm': mockFs.load(path.resolve(__dirname, './../datasets/pdf.dcm')),
       'fileInEmpty.dcm': '',
@@ -176,8 +176,8 @@ describe('Dataset', () => {
           Dataset.fromFile('fileInEmpty.dcm', (err4, dataset3) => {
             expect(err4).not.to.be.undefined;
             expect(dataset3).to.be.undefined;
-
             mockFs.restore();
+            done();
           });
         });
       });

--- a/test/Implementation.test.js
+++ b/test/Implementation.test.js
@@ -6,6 +6,18 @@ const chai = require('chai');
 const expect = chai.expect;
 
 describe('Implementation', () => {
+  beforeEach(() => {
+    Implementation.setImplementationClassUid(DefaultImplementation.ImplementationClassUid);
+    Implementation.setImplementationVersion(DefaultImplementation.ImplementationVersion);
+    Implementation.setMaxPduLength(DefaultImplementation.MaxPduLength);
+  });
+
+  afterEach(() => {
+    Implementation.setImplementationClassUid(DefaultImplementation.ImplementationClassUid);
+    Implementation.setImplementationVersion(DefaultImplementation.ImplementationVersion);
+    Implementation.setMaxPduLength(DefaultImplementation.MaxPduLength);
+  });
+
   it('should correctly get the default implementation', () => {
     expect(Implementation.getImplementationClassUid()).to.be.eq(
       DefaultImplementation.ImplementationClassUid
@@ -37,17 +49,5 @@ describe('Implementation', () => {
     expect(() => {
       Implementation.setImplementationVersion('12345678901234567');
     }).to.throw();
-  });
-
-  beforeEach(() => {
-    Implementation.setImplementationClassUid(DefaultImplementation.ImplementationClassUid);
-    Implementation.setImplementationVersion(DefaultImplementation.ImplementationVersion);
-    Implementation.setMaxPduLength(DefaultImplementation.MaxPduLength);
-  });
-
-  afterEach(() => {
-    Implementation.setImplementationClassUid(DefaultImplementation.ImplementationClassUid);
-    Implementation.setImplementationVersion(DefaultImplementation.ImplementationVersion);
-    Implementation.setMaxPduLength(DefaultImplementation.MaxPduLength);
   });
 });


### PR DESCRIPTION
An attempt was made to implement C-STORE SCP streaming support, based on the ideas discussed in https://github.com/PantelisGeorgiadis/dcmjs-dimse/issues/39. 
More specifically, the `Scp` class was enriched with two extra functions that give the caller the oppurtunity to create the stream that will receive the incoming fragment buffers and to translate the accumulated fragments back into a `Dataset`.
The functions are the `createStoreWritableStream` and the `createDatasetFromStoreWritableStream`, respectively. The first one provides to the user the accepted presentation context (to assess the dataset type and transfer syntax) and expects a Writable stream to be returned. The latter provides to the user the previously created Writable stream, the accepted presentation context and callback that could be used to return the parsed `Dataset`. The default implementation still uses memory buffers.

Bellow is a sample implementation of an `Scp` class that accumulates the incoming C-STORE data to temp file streams (using the `temp` library). Once the reception is over (last PDV fragment received), the files are read back into a `Dataset` which are passed to the `Scp.cStoreRequest` method for further processing (this is not a mandatory step - the callback can return undefined if there is no interest for passing the dataset in the `Scp.cStoreRequest` method).
```js
const temp = require('temp');

class StreamingScp extends Scp {
  constructor(socket, opts) {
    super(socket, opts);
    this.association = undefined;

    temp.track();
  }

  createStoreWritableStream(acceptedPresentationContext) {
    return temp.createWriteStream();
  }

  createDatasetFromStoreWritableStream(writable, acceptedPresentationContext, callback) {
    writable.on('finish', () => {
      const path = writable.path;
      const datasetBuffer = fs.readFileSync(path);
      const dataset = new Dataset(
        datasetBuffer,
        acceptedPresentationContext.getAcceptedTransferSyntaxUid()
      );
      callback(dataset);
    });
    writable.on('error', (err) => {
      callback(undefined);
    });
  }

  associationRequested(association) {
    this.association = association;

    const contexts = association.getPresentationContexts();
    contexts.forEach((c) => {
      const context = association.getPresentationContext(c.id);
      if (Object.values(StorageClass).includes(context.getAbstractSyntaxUid())) {
        const transferSyntaxes = context.getTransferSyntaxUids();
        transferSyntaxes.forEach((transferSyntax) => {
          if (
            transferSyntax === TransferSyntax.ImplicitVRLittleEndian ||
            transferSyntax === TransferSyntax.ExplicitVRLittleEndian
          ) {
            context.setResult(PresentationContextResult.Accept, transferSyntax);
          } else {
            context.setResult(PresentationContextResult.RejectTransferSyntaxesNotSupported);
          }
        });
      } else {
        context.setResult(PresentationContextResult.RejectAbstractSyntaxNotSupported);
      }
    });
    this.sendAssociationAccept();
  }

  cStoreRequest(request, callback) {
    console.log(request.getDataset());

    const response = CStoreResponse.fromRequest(request);
    response.setStatus(Status.Success);
    callback(response);
  }

  associationReleaseRequested() {
    this.sendAssociationReleaseResponse();
  }
}
```

@richard-viney, @kinsonho, please review and let me know of your thoughts.