### PR TITLE
Updated dataset read, write and nameMap options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -194,7 +194,11 @@ declare class Dataset {
   /**
    * Creates an instance of Dataset.
    */
-  constructor(elementsOrBuffer?: Record<string, unknown> | Buffer, transferSyntaxUid?: string);
+  constructor(
+    elementsOrBuffer?: Record<string, unknown> | Buffer,
+    transferSyntaxUid?: string,
+    readOptions?: Record<string, unknown>
+  );
 
   /**
    * Gets element value.
@@ -224,7 +228,10 @@ declare class Dataset {
   /**
    * Gets elements encoded in a DICOM dataset buffer.
    */
-  getDenaturalizedDataset(writeOptions?: Record<string, unknown>): Buffer;
+  getDenaturalizedDataset(
+    writeOptions?: Record<string, unknown>,
+    nameMap?: Record<string, unknown>
+  ): Buffer;
 
   /**
    * Gets command elements encoded in a DICOM dataset buffer.
@@ -1294,7 +1301,9 @@ declare class Network extends AsyncEventEmitter<AsyncEventEmitter.EventMap> {
       pduTimeout?: number;
       logCommandDatasets?: boolean;
       logDatasets?: boolean;
+      datasetReadOptions?: Record<string, unknown>;
       datasetWriteOptions?: Record<string, unknown>;
+      datasetNameMap?: Record<string, unknown>;
     }
   );
 
@@ -1393,6 +1402,9 @@ declare class Scp extends Network {
       pduTimeout?: number;
       logCommandDatasets?: boolean;
       logDatasets?: boolean;
+      datasetReadOptions?: Record<string, unknown>;
+      datasetWriteOptions?: Record<string, unknown>;
+      datasetNameMap?: Record<string, unknown>;
       securityOptions?: {
         key?: string | Array<string> | Buffer | Array<Buffer>;
         cert?: string | Array<string> | Buffer | Array<Buffer>;
@@ -1504,6 +1516,9 @@ declare class Server extends AsyncEventEmitter<AsyncEventEmitter.EventMap> {
       pduTimeout?: number;
       logCommandDatasets?: boolean;
       logDatasets?: boolean;
+      datasetReadOptions?: Record<string, unknown>;
+      datasetWriteOptions?: Record<string, unknown>;
+      datasetNameMap?: Record<string, unknown>;
       securityOptions?: {
         key?: string | Array<string> | Buffer | Array<Buffer>;
         cert?: string | Array<string> | Buffer | Array<Buffer>;
@@ -1566,7 +1581,9 @@ declare class Client extends AsyncEventEmitter<AsyncEventEmitter.EventMap> {
       associationLingerTimeout?: number;
       logCommandDatasets?: boolean;
       logDatasets?: boolean;
+      datasetReadOptions?: Record<string, unknown>;
       datasetWriteOptions?: Record<string, unknown>;
+      datasetNameMap?: Record<string, unknown>;
       asyncOps?: {
         maxAsyncOpsInvoked?: number;
         maxAsyncOpsPerformed?: number;
@@ -1585,9 +1602,6 @@ declare class Client extends AsyncEventEmitter<AsyncEventEmitter.EventMap> {
         rejectUnauthorized?: boolean;
         minVersion?: string;
         maxVersion?: string;
-        SNICallback?:
-          | ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void)
-          | undefined;
       };
     }
   ): void;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -442,6 +442,9 @@ class TestScp extends Scp {
       pduTimeout?: number;
       logCommandDatasets?: boolean;
       logDatasets?: boolean;
+      datasetReadOptions?: Record<string, unknown>;
+      datasetWriteOptions?: Record<string, unknown>;
+      datasetNameMap?: Record<string, unknown>;
       securityOptions?: {
         key?: Buffer;
         cert?: Buffer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dcmjs-dimse",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dcmjs-dimse",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "async-eventemitter": "^0.2.4",
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/async-eventemitter": "^0.2.1",
         "@types/node": "^20.2.5",
-        "c8": "^7.13.0",
+        "c8": "^7.14.0",
         "chai": "^4.3.7",
         "docdash": "^2.0.1",
         "eslint": "^8.41.0",
@@ -33,8 +33,8 @@
         "terser-webpack-plugin": "^5.3.9",
         "ts-node": "^10.9.1",
         "tsd": "^0.28.1",
-        "typescript": "^5.0.4",
-        "webpack": "^5.84.1",
+        "typescript": "^5.1.3",
+        "webpack": "^5.85.0",
         "webpack-cli": "^5.1.1"
       }
     },
@@ -1029,9 +1029,9 @@
       }
     },
     "node_modules/c8": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.13.0.tgz",
-      "integrity": "sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-7.14.0.tgz",
+      "integrity": "sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -5547,16 +5547,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {
@@ -5685,9 +5685,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.84.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.84.1.tgz",
-      "integrity": "sha512-ZP4qaZ7vVn/K8WN/p990SGATmrL1qg4heP/MrVneczYtpDGJWlrgZv55vxaV2ul885Kz+25MP2kSXkPe3LZfmg==",
+      "version": "5.85.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.85.0.tgz",
+      "integrity": "sha512-7gazTiYqwo5OSqwH1tigLDL2r3qDeP2dOKYgd+LlXpsUMqDTklg6tOghexqky0/+6QY38kb/R/uRPUleuL43zg==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -6824,9 +6824,9 @@
       }
     },
     "c8": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.13.0.tgz",
-      "integrity": "sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-7.14.0.tgz",
+      "integrity": "sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -10100,9 +10100,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true
     },
     "uc.micro": {
@@ -10200,9 +10200,9 @@
       }
     },
     "webpack": {
-      "version": "5.84.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.84.1.tgz",
-      "integrity": "sha512-ZP4qaZ7vVn/K8WN/p990SGATmrL1qg4heP/MrVneczYtpDGJWlrgZv55vxaV2ul885Kz+25MP2kSXkPe3LZfmg==",
+      "version": "5.85.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.85.0.tgz",
+      "integrity": "sha512-7gazTiYqwo5OSqwH1tigLDL2r3qDeP2dOKYgd+LlXpsUMqDTklg6tOghexqky0/+6QY38kb/R/uRPUleuL43zg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs-dimse",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "DICOM DIMSE implementation for Node.js using dcmjs",
   "main": "build/dcmjs-dimse.min.js",
   "module": "build/dcmjs-dimse.min.js",
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/async-eventemitter": "^0.2.1",
     "@types/node": "^20.2.5",
-    "c8": "^7.13.0",
+    "c8": "^7.14.0",
     "chai": "^4.3.7",
     "docdash": "^2.0.1",
     "eslint": "^8.41.0",
@@ -65,8 +65,8 @@
     "terser-webpack-plugin": "^5.3.9",
     "ts-node": "^10.9.1",
     "tsd": "^0.28.1",
-    "typescript": "^5.0.4",
-    "webpack": "^5.84.1",
+    "typescript": "^5.1.3",
+    "webpack": "^5.85.0",
     "webpack-cli": "^5.1.1"
   }
 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -86,7 +86,9 @@ class Client extends AsyncEventEmitter {
    * @param {number} [opts.associationLingerTimeout] - Association linger timeout in milliseconds.
    * @param {boolean} [opts.logCommandDatasets] - Log DIMSE command datasets.
    * @param {boolean} [opts.logDatasets] - Log DIMSE datasets.
+   * @param {Object} [opts.datasetReadOptions] - The read options to pass through to `DicomMessage._read()`.
    * @param {Object} [opts.datasetWriteOptions] - The write options to pass through to `DicomMessage.write()`.
+   * @param {Object} [opts.datasetNameMap] - Additional DICOM tags to recognize when denaturalizing the dataset.
    * @param {Object} [opts.asyncOps] - Asynchronous operations options.
    * @param {number} [opts.asyncOps.maxAsyncOpsInvoked] - Supported maximum number of asynchronous operations invoked.
    * @param {number} [opts.asyncOps.maxAsyncOpsPerformed] - Supported maximum number of asynchronous operations performed.
@@ -107,7 +109,6 @@ class Client extends AsyncEventEmitter {
    * 'TLSv1.3', 'TLSv1.2', 'TLSv1.1', or 'TLSv1'.
    * @param {string} [opts.securityOptions.maxVersion] - The maximum TLS version to allow. One of
    * 'TLSv1.3', 'TLSv1.2', 'TLSv1.1', or 'TLSv1'.
-   * @param {function} [opts.securityOptions.SNICallback] - A function that will be called if the client supports SNI TLS extension.
    * @throws Error if there are zero requests to perform.
    */
   send(host, port, callingAeTitle, calledAeTitle, opts) {
@@ -167,7 +168,6 @@ class Client extends AsyncEventEmitter {
         rejectUnauthorized: opts.securityOptions.rejectUnauthorized,
         minVersion: opts.securityOptions.minVersion,
         maxVersion: opts.securityOptions.maxVersion,
-        SNICallback: opts.securityOptions.SNICallback,
       };
     }
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -32,6 +32,9 @@ class Scp extends Network {
    * @param {number} [opts.pduTimeout] - PDU timeout in milliseconds.
    * @param {boolean} [opts.logCommandDatasets] - Log DIMSE command datasets.
    * @param {boolean} [opts.logDatasets] - Log DIMSE datasets.
+   * @param {Object} [opts.datasetReadOptions] - The read options to pass through to `DicomMessage._read()`.
+   * @param {Object} [opts.datasetWriteOptions] - The write options to pass through to `DicomMessage.write()`.
+   * @param {Object} [opts.datasetNameMap] - Additional DICOM tags to recognize when denaturalizing the dataset.
    * @param {Object} [opts.securityOptions] - Security options.
    * @param {string|Array<string>|Buffer|Array<Buffer>} [opts.securityOptions.key] - Server private key in PEM format.
    * @param {string|Array<string>|Buffer|Array<Buffer>} [opts.securityOptions.cert] - Server public certificate in PEM format.
@@ -288,6 +291,9 @@ class Server extends AsyncEventEmitter {
    * @param {number} [opts.pduTimeout] - PDU timeout in milliseconds.
    * @param {boolean} [opts.logCommandDatasets] - Log DIMSE command datasets.
    * @param {boolean} [opts.logDatasets] - Log DIMSE datasets.
+   * @param {Object} [opts.datasetReadOptions] - The read options to pass through to `DicomMessage._read()`.
+   * @param {Object} [opts.datasetWriteOptions] - The write options to pass through to `DicomMessage.write()`.
+   * @param {Object} [opts.datasetNameMap] - Additional DICOM tags to recognize when denaturalizing the dataset.
    * @param {Object} [opts.securityOptions] - Security options.
    * @param {string|Array<string>|Buffer|Array<Buffer>} [opts.securityOptions.key] - Server private key in PEM format.
    * @param {string|Array<string>|Buffer|Array<Buffer>} [opts.securityOptions.cert] - Server public certificate in PEM format.

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-module.exports = '0.1.18';
+module.exports = '0.1.19';

--- a/test/Association.test.js
+++ b/test/Association.test.js
@@ -1,5 +1,5 @@
 const { Association } = require('./../src/Association');
-const { CGetRequest, CStoreRequest, Request } = require('../src/Command');
+const { CGetRequest, CStoreRequest, Request } = require('./../src/Command');
 const {
   CommandFieldType,
   PresentationContextResult,
@@ -8,7 +8,7 @@ const {
   TransferSyntax,
   UserIdentityType,
 } = require('./../src/Constants');
-const Dataset = require('../src/Dataset');
+const Dataset = require('./../src/Dataset');
 
 const chai = require('chai');
 const expect = chai.expect;

--- a/test/Commands.test.js
+++ b/test/Commands.test.js
@@ -33,7 +33,7 @@ const {
   Status,
   TransferSyntax,
 } = require('./../src/Constants');
-const Dataset = require('../src/Dataset');
+const Dataset = require('./../src/Dataset');
 
 const chai = require('chai');
 const expect = chai.expect;

--- a/test/Dataset.test.js
+++ b/test/Dataset.test.js
@@ -43,6 +43,27 @@ describe('Dataset', () => {
     expect(dataset3.getElement('StudyDescription')).to.be.eq(studyDescription);
     expect(dataset3.getElement('SeriesDescription')).to.be.eq(seriesDescription);
     expect(dataset3.getTransferSyntaxUid()).to.be.eq(TransferSyntax.ExplicitVRLittleEndian);
+
+    const dicomDataset4 = dataset3.getDenaturalizedDataset();
+
+    const dataset5 = new Dataset(dicomDataset4, TransferSyntax.ExplicitVRLittleEndian, {
+      untilTag: '00080050', // AccessionNumber
+      includeUntilTagValue: false,
+    });
+    expect(dataset5.getElement('PatientID')).to.be.undefined;
+    expect(dataset5.getElement('PatientName')).to.be.undefined;
+    expect(dataset5.getElement('StudyDescription')).to.be.undefined;
+    expect(dataset5.getElement('SeriesDescription')).to.be.undefined;
+
+    const dataset6 = new Dataset(dicomDataset4, TransferSyntax.ExplicitVRLittleEndian, {
+      untilTag: '00080050', // AccessionNumber
+      includeUntilTagValue: true,
+    });
+    expect(dataset6.getElement('AccessionNumber')).to.be.eq(accessionNumber);
+    expect(dataset5.getElement('PatientID')).to.be.undefined;
+    expect(dataset5.getElement('PatientName')).to.be.undefined;
+    expect(dataset5.getElement('StudyDescription')).to.be.undefined;
+    expect(dataset5.getElement('SeriesDescription')).to.be.undefined;
   });
 
   it('should create at least 100 different DICOM UIDs sequentially', () => {

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -15,7 +15,7 @@ const {
   NEventReportResponse,
   NGetRequest,
   NGetResponse,
-} = require('../src/Command');
+} = require('./../src/Command');
 const {
   AbortReason,
   AbortSource,

--- a/test/Statistics.test.js
+++ b/test/Statistics.test.js
@@ -1,4 +1,4 @@
-const Statistics = require('../src/Statistics');
+const Statistics = require('./../src/Statistics');
 
 const chai = require('chai');
 const expect = chai.expect;


### PR DESCRIPTION
This closes #47.

The `Network`, `Client` and `Server` classes were updated to pass dataset read, write and nameMap options.