### PR TITLE
Fix unhandled exception reading non-DICOM file

### DIFF
--- a/src/Dataset.js
+++ b/src/Dataset.js
@@ -152,8 +152,7 @@ class Dataset {
           return;
         }
         try {
-          const result = this._fromP10Buffer(fileBuffer, readOptions)
-          callback(undefined, result);
+          callback(undefined, this._fromP10Buffer(fileBuffer, readOptions));
         } catch (error) {
           callback(error, undefined)
         }

--- a/src/Dataset.js
+++ b/src/Dataset.js
@@ -151,7 +151,12 @@ class Dataset {
           callback(error, undefined);
           return;
         }
-        callback(undefined, this._fromP10Buffer(fileBuffer, readOptions));
+        try {
+          const result = this._fromP10Buffer(fileBuffer, readOptions)
+          callback(undefined, result);
+        } catch (error) {
+          callback(error, undefined)
+        }
       });
       return;
     }

--- a/test/Dataset.test.js
+++ b/test/Dataset.test.js
@@ -166,4 +166,30 @@ describe('Dataset', () => {
       });
     });
   });
+
+  it('should throw Invalid DICOM file exception while reading non-DICOM files asynchronously', () => {
+    mockFs({
+      'fileIn.txt': mockFs.load(path.resolve(__dirname, '../datasets/non-dcm.txt')),
+    });
+    return new Promise((resolve, reject) => {
+      try {
+        Dataset.fromFile('fileIn.txt', (error, result) => {
+          if (error) {
+            return reject(error);
+          }
+
+          resolve(result);
+        });
+      } catch (error) {
+        reject(error);
+      }
+    }).catch((error) => {
+      expect(error.message).to.equal('Invalid DICOM file, expected header is missing');
+
+    }).then(() => {
+      mockFs.restore();
+    });
+
+  });
+
 });


### PR DESCRIPTION
Hello @PantelisGeorgiadis.
I faced an unhandled exception while trying to read some images downloaded from web with Dataset.fromFile (maybe file was corrupted).
This PR fixed this.